### PR TITLE
Correct the URL for supported dive computers.

### DIFF
--- a/about.MD
+++ b/about.MD
@@ -13,7 +13,7 @@ Subsurface also calculates a wide variety of **statistics** of the user’s divi
 
 The program is localized in about **20 languages** and well supported by an active developer community.
 
-One of the major strengths of Subsurface is its support of a wide range of **dive computers** (see the https://subsurface-divelog.org/documentation/supported-dive-computers/[list of supported dive computers]). Subsurface can also import existing dive logs from several sources including MacDive, Suunto DM3, DM4 & DM5, JDiveLog and divelogs.de.
+One of the major strengths of Subsurface is its support of a wide range of **dive computers** (see the [list of supported dive computers](https://subsurface-divelog.org/documentation/supported-dive-computers/)). Subsurface can also import existing dive logs from several sources including MacDive, Suunto DM3, DM4 & DM5, JDiveLog and divelogs.de.
 
 Another strength is its ability to **visualize** the depth profile (and, if available, the tank pressure curve) in innovative ways that give the user additional information on relative velocity, and momentary air consumption, during a dive. Users who dive with **multiple dive computers** can combine the data from each of their dive computers into one dive – allowing visualization of the data collected from multiple sources.
 


### PR DESCRIPTION
URL for supported dive computers looked mangled with the URL first and the
friendly name second, Markdown seems to prefer the friendly name first.

Signed off by: Jason Bramwell jb2cool@gmail.com