### PR TITLE
Add link to 3rd party repo for Debian packages

### DIFF
--- a/download.html
+++ b/download.html
@@ -73,6 +73,15 @@ Subsurface runs on Intel based Macs with macOS 10.12 or newer. For technical rea
 </a>
 </center>
 
+<h3>Debian</h3>
+<p>Packages for the most recent releases of Debian (generally for stable, testing, and unstable) for amd64 and i386 platforms are available via a 3rd party repository.</p>
+<center>
+<a class="face-button" href="https://dfx.at/subsurface-debian/">
+  <div class="face-primary"><i class="fas fa-external-link-alt"></i></i>Debian packages</div>
+  <div class="face-secondary"><i class="fas fa-external-link-alt"></i></i>Usage instructions</div>
+</a>
+</center>
+
 <h3>generic AppImage</h3>
 <p>If your distribution isn't supported above and you are running on an x86-64 platform, usually an AppImage is a viable solution. 
 You should be able to download this file, make it executable <code>chmod +x Subsurface-{{ site.latest }}-x86_64.AppImage</code> and then simply run this file.


### PR DESCRIPTION
As requested per mailing list

Currently available and maintained:

Archs: amd64 and i386

Releases: buster/stable, bullseye/testing, sid/unstable

Packages: Tagged releases "subsurface" and daily builds from git master "subsurface-beta"