### PR TITLE
Fix Typo in Header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -53,7 +53,7 @@
     {%- if page_paths -%}
         <div class="sidebar">
           <div class="logo">
-             <a href="https://subsuface-divelog.org"><img src="{{ "assets/subsurface-icon1.png" | relative_url }}"></a>
+             <a href="https://subsurface-divelog.org"><img src="{{ "assets/subsurface-icon1.png" | relative_url }}"></a>
           </div>
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}


### PR DESCRIPTION
Fixes typo in url, so clicking logo on subsurface website now works instead of pointing to a broken page.

![image](https://user-images.githubusercontent.com/1463882/166326331-fbe9e0cb-7743-4625-889a-f8899f4fdf8e.png)
