### PR TITLE
Fix broken Markdown link formatting in FAQ

### DIFF
--- a/faq.MD
+++ b/faq.MD
@@ -273,6 +273,6 @@ You need the correct USB driver in order to talk to the Descent Mk2/Mk2i:<br>- d
 
 If your question wasn't answered here, please check the [User Forum](https://subsurface-divelog.org/user-forum/) (try the search function) and if you don't find an answer there, create a new topic and ask for help.
 
-<p class="outside"> This FAQ is maintained on [GitHub](https://github.com/subsurface/subsurface.github.io) -- pull requests welcome.  <p>
+<p class="outside"> This FAQ is maintained on <a href="https://github.com/subsurface/subsurface.github.io">GitHub</a> -- pull requests welcome.  <p>
 
 

--- a/fr/faq.MD
+++ b/fr/faq.MD
@@ -80,6 +80,6 @@ Vous avez besoin du driver USB adéquat pour communiquer avec le Descent Mk2/Mk2
 
 Si votre question n'est pas abordée ici, veuillez consulter le [Forum utilisateurs](https://subsurface-divelog.org/user-forum/) (utilisez la fonction de recherche) et si vous n'y trouvez aucune réponse, créez un nouveau sujet et demandez de l'aide.
 
-<p class="outside"> Ce FAQ est maintenu sur [GitHub](https://github.com/subsurface/subsurface.github.io) -- les demandes de modifications sont bienvenues.  <p>
+<p class="outside"> Ce FAQ est maintenu sur <a href="https://github.com/subsurface/subsurface.github.io">GitHub</a> -- les demandes de modifications sont bienvenues.  <p>
 
 ***


### PR DESCRIPTION
Markdown formatting is not processed in HTML block tags, so use <a> tag instead.